### PR TITLE
Fix: DOC-6469 - Analytics

### DIFF
--- a/Sources/Amplitude/AMPDeviceInfo.m
+++ b/Sources/Amplitude/AMPDeviceInfo.m
@@ -177,7 +177,13 @@
 
 + (NSString *)getPlatformString {
 #if !TARGET_OS_OSX
-    const char *sysctl_name = "hw.machine";
+    char *sysctl_name = "hw.machine";
+    
+    if (@available(iOS 14.0, *)) {
+        if ([NSProcessInfo processInfo].isiOSAppOnMac) {
+            sysctl_name = "hw.model";
+        }
+    }
 #else
     const char *sysctl_name = "hw.model";
 #endif


### PR DESCRIPTION
hw.machine возвращает iPad, по просьбе Паши Сахатского вместо этого будет реальное название девайса