### PR TITLE
fix PEM-3558 – Amplitude database is stored in the root of ~/Library …

### DIFF
--- a/Sources/Amplitude/Amplitude.m
+++ b/Sources/Amplitude/Amplitude.m
@@ -215,7 +215,7 @@ static NSString *const SEQUENCE_NUMBER = @"sequence_number";
         _apiPropertiesTrackingOptions = [NSDictionary dictionary];
         _coppaControlEnabled = NO;
         self.instanceName = instanceName;
-        _dbHelper = [AMPDatabaseHelper getDatabaseHelper:instanceName];
+        _dbHelper = [AMPDatabaseHelper getDatabaseHelper:instanceName databaseDirectoryPath:eventsDataDirectory];
 
         self.eventUploadThreshold = kAMPEventUploadThreshold;
         self.eventMaxCount = kAMPEventMaxCount;


### PR DESCRIPTION
…instead of dedicated directory app in Application Support

Починяция для https://readdle-j.atlassian.net/browse/PEM-3558

Никита, ставлю на тебя, т.к. ты тут бывал