### PR TITLE
DOC-11886 Update privacy policy manifest for no tracking

### DIFF
--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -42,11 +42,6 @@
 		</dict>
 	</array>
 	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>https://api2.amplitude.com/</string>
-		<string>https://api.eu.amplitude.com/</string>
-		<string>https://regionconfig.amplitude.com/</string>
-		<string>https://regionconfig.eu.amplitude.com/</string>
-	</array>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
__Ticket link__

[DOC-11886](https://readdle-j.atlassian.net/browse/DOC-11886)

__PR description__

According to [documentation for Amplitude](https://www.docs.developers.amplitude.com/data/sdks/ios/#apple-privacy-manifest):
`If you set NSPrivacyTracking to true then you need to provide at least one internet domain in NSPrivacyTrackingDomains based on your configuraiton.`
As we don't set NSPrivacyTracking to YES (because there is supposed to be no privacy tracking) - NSPrivacyTrackingDomains should remain empty  

[DOC-11886]: https://readdle-j.atlassian.net/browse/DOC-11886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ