### PR TITLE
[beta-xcode] [DOC-16522] - Xcode27 adoption, PDFE

### DIFF
--- a/Amplitude.xcodeproj/project.pbxproj
+++ b/Amplitude.xcodeproj/project.pbxproj
@@ -1107,6 +1107,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1151,6 +1152,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sources/Amplitude/AMPUtils.m
+++ b/Sources/Amplitude/AMPUtils.m
@@ -175,7 +175,12 @@
 }
 
 + (UIWindow *)getKeyWindow {
-    for (UIWindow *window in [[AMPUtils getSharedApplication] windows]) {
+    UIWindowScene *scene = (UIWindowScene *)[[AMPUtils getSharedApplication].connectedScenes
+                                             objectsPassingTest:^BOOL(UIScene *nextScene, BOOL *stop) {
+        return [nextScene isKindOfClass:[UIWindowScene class]];
+    }].anyObject;
+    
+    for (UIWindow *window in scene.windows) {
         if ([window isKeyWindow]) {
             return window;
         }


### PR DESCRIPTION
[DOC-16522](https://readdle-j.atlassian.net/browse/DOC-16522)

__PR description__

- Changed ‘windows’ api from UIApplication to UIWindowScene
- Bumped deployment target to avoid warnings

__PR submission checklist__

- [ ] PR name contains Jira ticket number
- [ ] PR have correct target branch
- [ ] .s7substat has correct subrepos revisions
- [ ] Common ([Obj-C](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/3802038524/Common+Objective-C+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams) / [Swift](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4662394906/Common+Swift+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams)) and your team's coding conventions and style guidelines are followed
- [ ] All new UI components meet accessibility expectations according to the [Accessibility guide](https://readdle-c.atlassian.net/wiki/spaces/RD2/pages/5595496478/Accessibility+guide).
- [ ] Unit tests to cover the critical parts of the code are written
- [ ] Relevant documentation updated / added if needed [^1]
- [ ] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [ ] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed

[^1]: List of documents we maintain up to date:
    - [Accessibility Guide](https://readdle-c.atlassian.net/wiki/spaces/RD2/pages/5595496478/Accessibility+guide)


[DOC-16522]: https://readdle-j.atlassian.net/browse/DOC-16522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ